### PR TITLE
JDK 21 (WIP) - Close #3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ repositories {
 }
 
 dependencies {
-    api 'commons-cli:commons-cli:+'
+    api 'commons-cli:commons-cli:1.9.0'
     api 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.2'
 
     // We need to export this as API explicitly and fix the Versions

--- a/build.gradle
+++ b/build.gradle
@@ -71,47 +71,8 @@ dependencies {
     xmlDoclet 'net.sf.saxon:Saxon-HE:12.5'
 }
 
-def getVersion = { boolean considerSnapshot ->
-    Integer major = 0
-    Integer minor = 0
-    Integer patch = null
-    Integer build = null
-    def commit = null
-    def snapshot = ""
-    new ByteArrayOutputStream().withStream { os ->
-        exec {
-            args = [
-                    "--no-pager"
-                    , "describe"
-                    , "--tags"
-                    , "--always"
-                    , "--dirty=-SNAPSHOT"
-            ]
-            executable "git"
-            standardOutput = os
-        }
-        def versionStr = os.toString().trim()
-        def pattern = /(?<major>\d*)\.(?<minor>\d*)(\.(?<patch>\d*))?(-(?<build>\d*)-(?<commit>[a-zA-Z\d]*))?/
-        def matcher = versionStr =~ pattern
-        if (matcher.find()) {
-            major = matcher.group('major') as Integer
-            minor = matcher.group('minor') as Integer
-            patch = matcher.group('patch') as Integer
-            build = matcher.group('build') as Integer
-            commit = matcher.group('commit')
-        }
-
-        if (considerSnapshot && ( versionStr.endsWith('SNAPSHOT') || build!=null) ) {
-            minor++
-            if (patch!=null) patch = 0
-            snapshot = "-SNAPSHOT"
-        }
-    }
-    return patch!=null
-            ? "${major}.${minor}.${patch}${snapshot}"
-            :  "${major}.${minor}${snapshot}"
-}
-version = getVersion(true)
+tasks.register('customVersionTask', CustomVersionTask)
+version = tasks.named('customVersionTask').get().getVersion(true)
 group = 'com.manticore-projects.tools'
 description = 'XML Doclet'
 

--- a/build.gradle
+++ b/build.gradle
@@ -210,7 +210,7 @@ javadoc {
     if(JavaVersion.current().isJava9Compatible()) {
         options.addBooleanOption('html5', true)
     }
-    options.addBooleanOption("Xdoclint:none", true)
+    options.addBooleanOption("Xdoclint:none", false)
 }
 
 tasks.named('sourcesJar') {

--- a/build.gradle
+++ b/build.gradle
@@ -354,9 +354,8 @@ tasks.register('upload') {
 }
 
 tasks.register('gitChangelogTask', GitChangelogTask) {
-    fromRepo = file("$projectDir")
-    file = new File("${projectDir}/src/site/sphinx/changelog.md")
-    fromRef = "1.0"
+    fromRepo.set("$projectDir")
+    file.set(file("${projectDir}/src/site/sphinx/changelog.md"))
 }
 
 tasks.register('printModulePath') {

--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,7 @@ publishing {
     }
     repositories {
         maven {
-            name "ossrh"
+            name = "ossrh"
 
             def releasesRepoUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
             def snapshotsRepoUrl= "https://s01.oss.sonatype.org/content/repositories/snapshots/"
@@ -153,8 +153,8 @@ java {
     withSourcesJar()
     withJavadocJar()
 
-    sourceCompatibility(JavaVersion.VERSION_21)
-    targetCompatibility(JavaVersion.VERSION_21)
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(21))
@@ -304,11 +304,11 @@ spotless {
         target '*.rst', '*.md', '.gitignore'
         // define the steps to apply to those files
         trimTrailingWhitespace()
-        indentWithSpaces(4) // or spaces. Takes an integer argument if you don't like 4
+        leadingTabsToSpaces(4)
         endWithNewline()
     }
     java {
-        indentWithSpaces(4)
+        leadingTabsToSpaces(4)
         eclipse().configFile('config/formatter/eclipse-java-google-style.xml')
         target 'src/**/*.java'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -162,16 +162,6 @@ java {
     modularity.inferModulePath = true
 }
 
-compileJava {
-    doFirst {
-        options.compilerArgs += [
-                '--module-path', classpath.asPath,
-                '-Xmaxerrs', 1000
-        ]
-        classpath = files()
-    }
-}
-
 jar {
     manifest {
         attributes('Main-Class': 'com.github.markusbernhardt.xmldoclet.XmlDoclet')

--- a/buildSrc/src/main/groovy/CustomVersionTask.groovy
+++ b/buildSrc/src/main/groovy/CustomVersionTask.groovy
@@ -1,6 +1,7 @@
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecOperations
+
 import javax.inject.Inject
 
 class CustomVersionTask extends DefaultTask {
@@ -26,7 +27,6 @@ class CustomVersionTask extends DefaultTask {
         def commit = null
         def snapshot = ""
         new ByteArrayOutputStream().withStream { os ->
-            // TODO: use ExecOperations.exec
             execOperations.exec { spec ->
                 spec.args = [
                         "--no-pager"

--- a/src/main/java/com/github/markusbernhardt/xmldoclet/SupportedOptions.java
+++ b/src/main/java/com/github/markusbernhardt/xmldoclet/SupportedOptions.java
@@ -51,9 +51,8 @@ final class SupportedOptions {
     }
 
     private void newOneArgOption(final String optionName, final String description) {
-        final var parsedOptionName = parseOptionName(optionName);
-        final var option = Option.builder(parsedOptionName)
-                .argName(parsedOptionName)
+        final var option = Option.builder(optionName)
+                .argName(optionName)
                 .required(false)
                 .numberOfArgs(1)
                 .desc(description)
@@ -63,8 +62,8 @@ final class SupportedOptions {
     }
 
     private void newArgOption(final String optionName, final String argName, final String description) {
-        final var option = Option.builder(parseOptionName(optionName))
-                .argName(parseOptionName(argName))
+        final var option = Option.builder(optionName)
+                .argName(argName)
                 .required(false)
                 .hasArg()
                 .desc(description)
@@ -73,14 +72,9 @@ final class SupportedOptions {
         cliOptions.addOption(option);
     }
 
-    private static String parseOptionName(final String optionName) {
-        return optionName.startsWith("-") ? optionName : "-" + optionName;
-    }
-
     private void newNoArgOption(final String optionName, final String description) {
-        final var parsedOptionName = parseOptionName(optionName);
-        final var option = Option.builder(parsedOptionName)
-                .argName(parsedOptionName)
+        final var option = Option.builder(optionName)
+                .argName(optionName)
                 .required(false)
                 .hasArg(false)
                 .desc(description)

--- a/src/main/java/com/github/markusbernhardt/xmldoclet/XmlDoclet.java
+++ b/src/main/java/com/github/markusbernhardt/xmldoclet/XmlDoclet.java
@@ -51,9 +51,14 @@ public class XmlDoclet implements Doclet {
     private PrintWriter stdout;
 
     public XmlDoclet() {
-        final var supportedOptions = new SupportedOptions();
-        this.cliOptions = supportedOptions.get();
-        this.options = supportedOptions.toDocletOptions();
+        try {
+            final var supportedOptions = new SupportedOptions();
+            this.cliOptions = supportedOptions.get();
+            this.options = supportedOptions.toDocletOptions();
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "Failed to initialize XmlDoclet", e);
+            throw e;
+        }
     }
 
     @Override

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,9 +1,0 @@
-module xml.doclet.main {
-    requires jakarta.xml.bind;
-    requires java.logging;
-    requires jdk.javadoc;
-    requires Saxon.HE;
-    requires org.apache.commons.cli;
-
-    exports com.github.markusbernhardt.xmldoclet;
-}


### PR DESCRIPTION
# Close #3 

## Changes so far

Fix gradle build and some deprecations.
To generate the fat jar you have to run `./gradlew shadowJar`

It will create a xml-doclet-all.jar inside build/libs.
The doclet is not running yet.
You can start it by typing:

```bash
javadoc -doclet 'com.github.markusbernhardt.xmldoclet.XmlDoclet' -docletpath './build/libs/xml-doclet-all.jar' -J-ea -verbose
```

@manticore-projects, I don't know if you are making some changes too, because that may cause merge conflicts. 

Finally, since this is an independent fork, what do you think of detaching it from the original project?
This way, the following options on the repo home page will desapear and it will be easier to open PRs from feature branches (currently, a new PR targets the original repo).

![Screenshot 2025-01-13 at 21 50 32](https://github.com/user-attachments/assets/80bbebdf-0632-4896-b1bb-625c9ce95ebc)


To detach the project, you just need to access https://support.github.com/tickets/personal/0 and click "New Ticket". Then, send a message to the support, informing that now you have an independent fork that you want to detach from the original project.

I'll try to figure out why the doclet is not running. The major challenge is that there is no logs, just a generic error message "error: Could not instantiate class com.github.markusbernhardt.xmldoclet.XmlDoclet"
