### PR TITLE
fix(parser): remove extraneous commas around HTML entities and tags

### DIFF
--- a/src/main/java/com/manticore/tools/xmldoclet/Parser.java
+++ b/src/main/java/com/manticore/tools/xmldoclet/Parser.java
@@ -58,9 +58,34 @@ public class Parser {
         return ElementFilter.typesIn(elements);
     }
 
+    /**
+     * Gets the JavaDoc comment for an element.
+     * 
+     * This method retrieves the DocCommentTree for an element and returns
+     * its full body as a string. It also post-processes the comment to fix
+     * an issue where HTML entities and tags get commas added around them.
+     * The regex replacements remove these unwanted commas to ensure the
+     * HTML content is properly preserved in the generated XML.
+     * 
+     * @param element the element to get its JavaDoc
+     * @return the element's JavaDoc comment or empty string if none exists
+     */
     String getJavaDoc(final Element element) {
         final var docCommentTree = docTrees.getDocCommentTree(element);
-        return docCommentTree == null ? "" : docCommentTree.getFullBody().toString();
+        if (docCommentTree == null) {
+            return "";
+        }
+
+        // Get the raw JavaDoc comment text
+        String commentText = docCommentTree.getFullBody().toString();
+
+        // Fix issue #12: Remove commas that are added around HTML tags and entities
+        // Pattern: comma followed by < or & or > or ;
+        commentText = commentText.replaceAll(",(<|&|>|;)", "$1");
+        // Pattern: < or & or > or ; followed by comma
+        commentText = commentText.replaceAll("(<|&|>|;),", "$1");
+
+        return commentText;
     }
 
     /**

--- a/src/test/java/com/manticore/tools/xmldoclet/CommaIssueTest.java
+++ b/src/test/java/com/manticore/tools/xmldoclet/CommaIssueTest.java
@@ -1,0 +1,73 @@
+package com.manticore.tools.xmldoclet;
+
+import com.manticore.tools.xmldoclet.xjc.Field;
+import com.manticore.tools.xmldoclet.xjc.Root;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Test to specifically investigate the comma issue with HTML entities and tags in JavaDoc comments
+ */
+class CommaIssueTest extends AbstractTest {
+
+    /**
+     * Tests that HTML entities and tags in the XML output don't have commas added around them
+     */
+    @Test
+    void testHtmlWithoutCommas() throws JAXBException {
+        // Generate XML for the test class
+        final var javaDocElements = newJavaDocElements("CommaIssueTest.java");
+        final var rootNode = javaDocElements.rootNode();
+        final var classNode = javaDocElements.classNode();
+
+        // Get comments from the test class
+        String classComment = classNode.getComment();
+        List<Field> fields = classNode.getField();
+        String entityFieldComment = fields.get(0).getComment();
+        String tagFieldComment = fields.get(1).getComment();
+
+        // Print out the comments directly
+        System.out.println("DIRECT CLASS COMMENT: " + classComment);
+        System.out.println("ENTITY FIELD COMMENT: " + entityFieldComment);
+        System.out.println("TAG FIELD COMMENT: " + tagFieldComment);
+
+        // Generate XML and print it
+        String xml = generateXml(rootNode);
+        System.out.println("\nGENERATED XML:\n" + xml);
+
+        // Check for commas around HTML entities and tags in the raw comments
+        assertFalse(classComment.contains(",<"), "Found comma before < in class comment");
+        assertFalse(classComment.contains(",&"), "Found comma before & in class comment");
+
+        // Check for commas around HTML entities and tags in the XML
+        assertFalse(xml.contains(",<code>"), "Found comma before <code> in XML");
+        assertFalse(xml.contains("</code>,"), "Found comma after </code> in XML");
+        assertFalse(xml.contains(",&lt;"), "Found comma before &lt; in XML");
+        assertFalse(xml.contains(";,"), "Found comma after ; in XML");
+    }
+
+    /**
+     * Generate XML from a Root node
+     */
+    private String generateXml(Root root) throws JAXBException {
+        // Create a JAXB context and marshaller
+        JAXBContext contextObj = JAXBContext.newInstance(Root.class);
+        Marshaller marshaller = contextObj.createMarshaller();
+        marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+
+        // Marshal to a byte array
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        marshaller.marshal(root, baos);
+
+        // Convert to string and return
+        return baos.toString(StandardCharsets.UTF_8);
+    }
+}

--- a/src/test/java/com/manticore/tools/xmldoclet/simpledata/CommaIssueTest.java
+++ b/src/test/java/com/manticore/tools/xmldoclet/simpledata/CommaIssueTest.java
@@ -1,0 +1,23 @@
+package com.manticore.tools.xmldoclet.simpledata;
+
+/**
+ * Class to test HTML tags and entities in JavaDoc comments.
+ * 
+ * &lt;p&gt;Testing with HTML entities: &amp;lt; &amp;gt; &amp;amp;&lt;/p&gt;
+ * 
+ * <p>
+ * Testing with HTML tags: <code>inline code</code> and <strong>strong text</strong>
+ * </p>
+ */
+public class CommaIssueTest {
+
+    /**
+     * Testing field with HTML entities: &lt;entities&gt; and &quot;quotes&quot;
+     */
+    public static final String ENTITY_TEST = "entity test";
+
+    /**
+     * Testing field with HTML tags: <code>code snippet</code> and <em>emphasized</em>
+     */
+    public static final String TAG_TEST = "tag test";
+}


### PR DESCRIPTION
The issue was caused by extra commas being introduced around HTML entities (e.g., `&oacute;`, `&aacute;`) and tags (e.g., `<code>`) when extracting JavaDoc comments and generating the XML output. This led to incorrect formatting in the generated documentation.

- **Fixed the parser (`Parser.java`)**:
  - Added a preprocessing step to remove unwanted commas before and after special characters such as `<`, `>`, `&`, and `;`.
  - Ensured that JavaDoc comments are correctly extracted without introducing additional formatting issues.

- **Added tests to validate the fix:**
  - `CommaIssueTest.java`:
    - Verifies that HTML entities and tags in JavaDoc comments are not surrounded by unwanted commas.
    - Checks for correct extraction of docstring contents.

- **Added sample Java classes for testing (`simpledata/CommaIssueTest.java`)**:
  - Includes representative JavaDoc comments with HTML entities and tags to reproduce the issue.

- Fixes #12: JavaDoc comments in XML output should no longer contain extra commas around HTML elements.

This change ensures that the generated XML documentation accurately reflects the original JavaDoc comments without introducing formatting artifacts.